### PR TITLE
Allow users to filter games by category and publisher

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,6 +35,8 @@ This is a crowdfunding platform for games with a developer theme. The applicatio
 - When writing C#, you must use type annotations for return values and method parameters.
 - Use nullable reference types when appropriate so generated code clearly communicates nullability expectations.
 - Follow C# naming conventions (PascalCase for public members, camelCase for locals)
+- Every public method should have XML doc comments or the language equivalent.
+- Before the namespace declaration or any code, add a comment block to the file that explains its purpose.
 
 ### C# and ASP.NET Core Patterns
 

--- a/.github/skills/branches-commits-prs/SKILL.md
+++ b/.github/skills/branches-commits-prs/SKILL.md
@@ -32,6 +32,7 @@ When creating a pull request:
 - Provide a clear title describing the changes which have been made
 - In the body content of the PR:
   - Start with a description of *why* the changes were made based on the conversation history
+  - If the PR resolves a linked issue, include an explicit closing keyword such as `Fixes #123` for bug fixes or `Closes #123` for feature work
   - Include a quick list of changes as a bulleted list
   - Provide additional details grouped together logically, following good accessibility practices for headers
   - Include code snippets for important changes

--- a/client/TailspinToys.E2E/FilterTests.cs
+++ b/client/TailspinToys.E2E/FilterTests.cs
@@ -9,13 +9,24 @@ namespace TailspinToys.E2E;
 public class FilterTests : PlaywrightTestBase
 {
     /// <summary>
+    /// Waits for the Blazor interactive circuit to be established on the home page.
+    /// OnAfterRenderAsync sets data-blazor-connected="true" only in the interactive render,
+    /// never in the SSR pre-render, so this reliably guards against clicking before the
+    /// circuit is ready.
+    /// </summary>
+    private async Task WaitForInteractiveAsync()
+    {
+        await Page.GotoAsync("/");
+        await Page.WaitForSelectorAsync("[data-blazor-connected='true']", new() { Timeout = 15000 });
+    }
+
+    /// <summary>
     /// The filter panel should be visible on the home page.
     /// </summary>
     [Fact]
     public async Task ShouldDisplayFilterPanel()
     {
-        await Page.GotoAsync("/");
-        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+        await WaitForInteractiveAsync();
 
         await Expect(Page.GetByTestId("game-filter")).ToBeVisibleAsync();
     }
@@ -27,8 +38,7 @@ public class FilterTests : PlaywrightTestBase
     [Fact]
     public async Task ShouldFilterGamesByCategoryBadge()
     {
-        await Page.GotoAsync("/");
-        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+        await WaitForInteractiveAsync();
 
         var initialCount = await Page.GetByTestId("game-card").CountAsync();
 
@@ -60,8 +70,7 @@ public class FilterTests : PlaywrightTestBase
     [Fact]
     public async Task ShouldFilterGamesByPublisherBadge()
     {
-        await Page.GotoAsync("/");
-        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+        await WaitForInteractiveAsync();
 
         // Click the first publisher badge
         var firstPublisherBadge = Page.Locator("[data-testid^='filter-publisher-']").First;
@@ -89,8 +98,7 @@ public class FilterTests : PlaywrightTestBase
     [Fact]
     public async Task ShouldCombineCategoryAndPublisherFilters()
     {
-        await Page.GotoAsync("/");
-        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+        await WaitForInteractiveAsync();
 
         var unfilteredCount = await Page.GetByTestId("game-card").CountAsync();
 
@@ -123,8 +131,7 @@ public class FilterTests : PlaywrightTestBase
     [Fact]
     public async Task ShouldClearFiltersAndRestoreFullList()
     {
-        await Page.GotoAsync("/");
-        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+        await WaitForInteractiveAsync();
 
         var unfilteredCount = await Page.GetByTestId("game-card").CountAsync();
 
@@ -156,8 +163,7 @@ public class FilterTests : PlaywrightTestBase
     [Fact]
     public async Task ShouldDeselectFilterBadgeOnSecondClick()
     {
-        await Page.GotoAsync("/");
-        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+        await WaitForInteractiveAsync();
 
         var unfilteredCount = await Page.GetByTestId("game-card").CountAsync();
 

--- a/client/TailspinToys.E2E/FilterTests.cs
+++ b/client/TailspinToys.E2E/FilterTests.cs
@@ -1,0 +1,182 @@
+// This file contains E2E tests for the game filtering functionality on the home page.
+using Microsoft.Playwright;
+
+namespace TailspinToys.E2E;
+
+/// <summary>
+/// E2E tests for the category and publisher filter UI on the games list page.
+/// </summary>
+public class FilterTests : PlaywrightTestBase
+{
+    /// <summary>
+    /// The filter panel should be visible on the home page.
+    /// </summary>
+    [Fact]
+    public async Task ShouldDisplayFilterPanel()
+    {
+        await Page.GotoAsync("/");
+        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+
+        await Expect(Page.GetByTestId("game-filter")).ToBeVisibleAsync();
+    }
+
+    /// <summary>
+    /// Clicking a category badge should filter the games grid to show only games
+    /// in that category, and the badge should appear active (aria-pressed=true).
+    /// </summary>
+    [Fact]
+    public async Task ShouldFilterGamesByCategoryBadge()
+    {
+        await Page.GotoAsync("/");
+        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+
+        var initialCount = await Page.GetByTestId("game-card").CountAsync();
+
+        // Click the first category badge
+        var firstCategoryBadge = Page.Locator("[data-testid^='filter-category-']").First;
+        await Expect(firstCategoryBadge).ToBeVisibleAsync();
+        var badgeText = await firstCategoryBadge.InnerTextAsync();
+        await firstCategoryBadge.ClickAsync();
+
+        // Badge should be marked active
+        await Expect(firstCategoryBadge).ToHaveAttributeAsync("aria-pressed", "true");
+
+        // Games grid should still be visible (possibly with fewer games)
+        await Expect(Page.GetByTestId("games-grid")).ToBeVisibleAsync();
+
+        // Each visible game-category badge should match the selected category
+        var gameCategoryBadges = Page.GetByTestId("game-category");
+        var count = await gameCategoryBadges.CountAsync();
+        for (var i = 0; i < count; i++)
+        {
+            await Expect(gameCategoryBadges.Nth(i)).ToHaveTextAsync(badgeText);
+        }
+    }
+
+    /// <summary>
+    /// Clicking a publisher badge should filter the grid to only show games
+    /// from that publisher, and the badge should appear active.
+    /// </summary>
+    [Fact]
+    public async Task ShouldFilterGamesByPublisherBadge()
+    {
+        await Page.GotoAsync("/");
+        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+
+        // Click the first publisher badge
+        var firstPublisherBadge = Page.Locator("[data-testid^='filter-publisher-']").First;
+        await Expect(firstPublisherBadge).ToBeVisibleAsync();
+        var badgeText = await firstPublisherBadge.InnerTextAsync();
+        await firstPublisherBadge.ClickAsync();
+
+        // Badge should be active
+        await Expect(firstPublisherBadge).ToHaveAttributeAsync("aria-pressed", "true");
+
+        // Each visible game-publisher badge should match the selected publisher
+        await Expect(Page.GetByTestId("games-grid")).ToBeVisibleAsync();
+
+        var gamePublisherBadges = Page.GetByTestId("game-publisher");
+        var count = await gamePublisherBadges.CountAsync();
+        for (var i = 0; i < count; i++)
+        {
+            await Expect(gamePublisherBadges.Nth(i)).ToHaveTextAsync(badgeText);
+        }
+    }
+
+    /// <summary>
+    /// Clicking a category and a publisher badge should narrow results to the intersection.
+    /// </summary>
+    [Fact]
+    public async Task ShouldCombineCategoryAndPublisherFilters()
+    {
+        await Page.GotoAsync("/");
+        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+
+        var unfilteredCount = await Page.GetByTestId("game-card").CountAsync();
+
+        // Apply category filter
+        var categoryBadge = Page.Locator("[data-testid^='filter-category-']").First;
+        await categoryBadge.ClickAsync();
+        await Expect(categoryBadge).ToHaveAttributeAsync("aria-pressed", "true");
+
+        // Apply publisher filter on top
+        var publisherBadge = Page.Locator("[data-testid^='filter-publisher-']").First;
+        await publisherBadge.ClickAsync();
+        await Expect(publisherBadge).ToHaveAttributeAsync("aria-pressed", "true");
+
+        // Result should be ≤ number of games from either filter alone
+        // (grid is shown or EmptyState is shown — neither is an error)
+        var gridVisible = await Page.GetByTestId("games-grid").IsVisibleAsync();
+        var emptyVisible = await Page.GetByTestId("empty-state").IsVisibleAsync();
+        Assert.True(gridVisible || emptyVisible, "Expected games-grid or empty-state after combined filter");
+
+        if (gridVisible)
+        {
+            var filteredCount = await Page.GetByTestId("game-card").CountAsync();
+            Assert.True(filteredCount <= unfilteredCount);
+        }
+    }
+
+    /// <summary>
+    /// Clicking the "Clear filters" button should restore the full unfiltered game list.
+    /// </summary>
+    [Fact]
+    public async Task ShouldClearFiltersAndRestoreFullList()
+    {
+        await Page.GotoAsync("/");
+        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+
+        var unfilteredCount = await Page.GetByTestId("game-card").CountAsync();
+
+        // Apply a filter to trigger the clear button
+        var categoryBadge = Page.Locator("[data-testid^='filter-category-']").First;
+        await categoryBadge.ClickAsync();
+        await Expect(categoryBadge).ToHaveAttributeAsync("aria-pressed", "true");
+
+        // Clear button should now be visible
+        var clearButton = Page.GetByTestId("filter-clear");
+        await Expect(clearButton).ToBeVisibleAsync();
+        await clearButton.ClickAsync();
+
+        // Badge should no longer be active
+        await Expect(categoryBadge).ToHaveAttributeAsync("aria-pressed", "false");
+
+        // Clear button should be gone
+        await Expect(clearButton).Not.ToBeVisibleAsync();
+
+        // Full game count should be restored
+        await Expect(Page.GetByTestId("games-grid")).ToBeVisibleAsync();
+        var restoredCount = await Page.GetByTestId("game-card").CountAsync();
+        Assert.Equal(unfilteredCount, restoredCount);
+    }
+
+    /// <summary>
+    /// Clicking an active filter badge a second time should deselect it.
+    /// </summary>
+    [Fact]
+    public async Task ShouldDeselectFilterBadgeOnSecondClick()
+    {
+        await Page.GotoAsync("/");
+        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+
+        var unfilteredCount = await Page.GetByTestId("game-card").CountAsync();
+
+        var categoryBadge = Page.Locator("[data-testid^='filter-category-']").First;
+
+        // First click — select
+        await categoryBadge.ClickAsync();
+        await Expect(categoryBadge).ToHaveAttributeAsync("aria-pressed", "true");
+
+        // Second click — deselect
+        await categoryBadge.ClickAsync();
+        await Expect(categoryBadge).ToHaveAttributeAsync("aria-pressed", "false");
+
+        // Full list should be restored
+        await Expect(Page.GetByTestId("games-grid")).ToBeVisibleAsync();
+        var restoredCount = await Page.GetByTestId("game-card").CountAsync();
+        Assert.Equal(unfilteredCount, restoredCount);
+    }
+
+    private static ILocatorAssertions Expect(ILocator locator) => Assertions.Expect(locator);
+    private static IPageAssertions Expect(IPage page) => Assertions.Expect(page);
+}

--- a/client/TailspinToys.Web/Components/Shared/EmptyState.razor
+++ b/client/TailspinToys.Web/Components/Shared/EmptyState.razor
@@ -1,4 +1,4 @@
-<div class="text-center py-12 bg-slate-800/50 backdrop-blur-sm rounded-xl border border-slate-700">
+<div data-testid="empty-state" class="text-center py-12 bg-slate-800/50 backdrop-blur-sm rounded-xl border border-slate-700">
     <p class="text-slate-300">@Message</p>
 </div>
 

--- a/client/TailspinToys.Web/Components/Shared/GameFilter.razor
+++ b/client/TailspinToys.Web/Components/Shared/GameFilter.razor
@@ -1,6 +1,7 @@
 @* GameFilter.razor - Renders category and publisher filter badge pills.
-   Emits FilterChanged when the user toggles a filter or clears all filters. *@
-@rendermode InteractiveServer
+   Emits FilterChanged when the user toggles a filter or clears all filters.
+   Note: no @rendermode directive here — this component is always rendered as a
+   child of the already-interactive GameList component. *@
 @using TailspinToys.Web.Models
 @inject IHttpClientFactory HttpClientFactory
 

--- a/client/TailspinToys.Web/Components/Shared/GameFilter.razor
+++ b/client/TailspinToys.Web/Components/Shared/GameFilter.razor
@@ -1,0 +1,119 @@
+@* GameFilter.razor - Renders category and publisher filter badge pills.
+   Emits FilterChanged when the user toggles a filter or clears all filters. *@
+@rendermode InteractiveServer
+@using TailspinToys.Web.Models
+@inject IHttpClientFactory HttpClientFactory
+
+@if (categories.Length > 0 || publishers.Length > 0)
+{
+    <div data-testid="game-filter" class="mb-8 p-5 bg-slate-800/60 backdrop-blur-sm rounded-xl border border-slate-700/50">
+        @if (categories.Length > 0)
+        {
+            <div class="mb-4">
+                <h3 class="text-xs font-semibold uppercase tracking-wider text-slate-400 mb-2">Category</h3>
+                <div class="flex flex-wrap gap-2">
+                    @foreach (var cat in categories)
+                    {
+                        var isActive = filterState.CategoryId == cat.Id;
+                        <button data-testid="filter-category-@cat.Id"
+                                aria-pressed="@isActive.ToString().ToLower()"
+                                aria-label="Filter by category @cat.Name"
+                                class="@CategoryBadgeClass(isActive) transition-all duration-200"
+                                @onclick="() => ToggleCategory(cat.Id)">
+                            @cat.Name
+                        </button>
+                    }
+                </div>
+            </div>
+        }
+
+        @if (publishers.Length > 0)
+        {
+            <div class="mb-4">
+                <h3 class="text-xs font-semibold uppercase tracking-wider text-slate-400 mb-2">Publisher</h3>
+                <div class="flex flex-wrap gap-2">
+                    @foreach (var pub in publishers)
+                    {
+                        var isActive = filterState.PublisherId == pub.Id;
+                        <button data-testid="filter-publisher-@pub.Id"
+                                aria-pressed="@isActive.ToString().ToLower()"
+                                aria-label="Filter by publisher @pub.Name"
+                                class="@PublisherBadgeClass(isActive) transition-all duration-200"
+                                @onclick="() => TogglePublisher(pub.Id)">
+                            @pub.Name
+                        </button>
+                    }
+                </div>
+            </div>
+        }
+
+        @if (filterState.HasActiveFilters)
+        {
+            <div class="border-t border-slate-700/50 pt-3 mt-1">
+                <button data-testid="filter-clear"
+                        aria-label="Clear all filters"
+                        class="text-sm text-slate-400 hover:text-slate-100 transition-colors duration-200 flex items-center gap-1"
+                        @onclick="ClearFilters">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                        <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+                    </svg>
+                    Clear filters
+                </button>
+            </div>
+        }
+    </div>
+}
+
+@code {
+    [Parameter]
+    public EventCallback<GameFilterState> FilterChanged { get; set; }
+
+    private FilterOption[] categories = [];
+    private FilterOption[] publishers = [];
+    private GameFilterState filterState = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        var client = HttpClientFactory.CreateClient("API");
+
+        try
+        {
+            var cats  = await client.GetFromJsonAsync<FilterOption[]>("api/categories");
+            var pubs  = await client.GetFromJsonAsync<FilterOption[]>("api/publishers");
+            categories = cats ?? [];
+            publishers = pubs ?? [];
+        }
+        catch
+        {
+            // If the fetch fails, the filter simply renders nothing
+        }
+    }
+
+    private async Task ToggleCategory(int id)
+    {
+        filterState.CategoryId = filterState.CategoryId == id ? null : id;
+        await FilterChanged.InvokeAsync(filterState);
+    }
+
+    private async Task TogglePublisher(int id)
+    {
+        filterState.PublisherId = filterState.PublisherId == id ? null : id;
+        await FilterChanged.InvokeAsync(filterState);
+    }
+
+    private async Task ClearFilters()
+    {
+        filterState = new GameFilterState();
+        await FilterChanged.InvokeAsync(filterState);
+    }
+
+    private static string CategoryBadgeClass(bool active) => active
+        ? "text-xs font-semibold px-3 py-1 rounded-full bg-blue-600 text-white border border-blue-500 cursor-pointer"
+        : "text-xs font-semibold px-3 py-1 rounded-full bg-blue-900/40 text-blue-300 border border-blue-800/50 hover:bg-blue-900/70 cursor-pointer";
+
+    private static string PublisherBadgeClass(bool active) => active
+        ? "text-xs font-semibold px-3 py-1 rounded-full bg-purple-600 text-white border border-purple-500 cursor-pointer"
+        : "text-xs font-semibold px-3 py-1 rounded-full bg-purple-900/40 text-purple-300 border border-purple-800/50 hover:bg-purple-900/70 cursor-pointer";
+
+    private record FilterOption(int Id, string Name);
+}

--- a/client/TailspinToys.Web/Components/Shared/GameList.razor
+++ b/client/TailspinToys.Web/Components/Shared/GameList.razor
@@ -1,8 +1,11 @@
 @rendermode InteractiveServer
+@using TailspinToys.Web.Models
 @inject IHttpClientFactory HttpClientFactory
 
 <div>
     <h2 class="text-2xl font-medium mb-6 text-slate-100">Featured Games</h2>
+
+    <GameFilter FilterChanged="OnFilterChanged" />
 
     @if (isLoading)
     {
@@ -31,13 +34,28 @@
     private Game[]? games;
     private bool isLoading = true;
     private string? errorMessage;
+    private GameFilterState currentFilter = new();
 
     protected override async Task OnInitializedAsync()
+    {
+        await FetchGames();
+    }
+
+    private async Task OnFilterChanged(GameFilterState filter)
+    {
+        currentFilter = filter;
+        isLoading = true;
+        errorMessage = null;
+        await FetchGames();
+    }
+
+    private async Task FetchGames()
     {
         try
         {
             var client = HttpClientFactory.CreateClient("API");
-            var response = await client.GetAsync("api/games");
+            var url = BuildUrl();
+            var response = await client.GetAsync(url);
 
             if (response.IsSuccessStatusCode)
             {
@@ -56,5 +74,19 @@
         {
             isLoading = false;
         }
+    }
+
+    private string BuildUrl()
+    {
+        var url = "api/games";
+        var queryParams = new List<string>();
+
+        if (currentFilter.CategoryId.HasValue)
+            queryParams.Add($"categoryId={currentFilter.CategoryId.Value}");
+
+        if (currentFilter.PublisherId.HasValue)
+            queryParams.Add($"publisherId={currentFilter.PublisherId.Value}");
+
+        return queryParams.Count > 0 ? $"{url}?{string.Join("&", queryParams)}" : url;
     }
 }

--- a/client/TailspinToys.Web/Components/Shared/GameList.razor
+++ b/client/TailspinToys.Web/Components/Shared/GameList.razor
@@ -2,7 +2,7 @@
 @using TailspinToys.Web.Models
 @inject IHttpClientFactory HttpClientFactory
 
-<div>
+<div data-blazor-connected="@(_blazorConnected ? "true" : "false")">
     <h2 class="text-2xl font-medium mb-6 text-slate-100">Featured Games</h2>
 
     <GameFilter FilterChanged="OnFilterChanged" />
@@ -35,10 +35,24 @@
     private bool isLoading = true;
     private string? errorMessage;
     private GameFilterState currentFilter = new();
+    // Set to true only after the interactive Blazor circuit fires OnAfterRenderAsync.
+    // Pre-rendered HTML always has data-blazor-connected="false"; tests wait for "true"
+    // to ensure clicks are processed by the live circuit, not the static SSR snapshot.
+    private bool _blazorConnected = false;
 
     protected override async Task OnInitializedAsync()
     {
         await FetchGames();
+    }
+
+    protected override Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && !_blazorConnected)
+        {
+            _blazorConnected = true;
+            StateHasChanged();
+        }
+        return Task.CompletedTask;
     }
 
     private async Task OnFilterChanged(GameFilterState filter)

--- a/client/TailspinToys.Web/Models/GameFilterState.cs
+++ b/client/TailspinToys.Web/Models/GameFilterState.cs
@@ -1,0 +1,18 @@
+// This file defines the filter state model used by the GameFilter component.
+namespace TailspinToys.Web.Models;
+
+/// <summary>
+/// Holds the currently selected category and publisher filter values.
+/// Null means no filter is applied for that dimension.
+/// </summary>
+public class GameFilterState
+{
+    /// <summary>The selected category ID, or null if no category filter is active.</summary>
+    public int? CategoryId { get; set; }
+
+    /// <summary>The selected publisher ID, or null if no publisher filter is active.</summary>
+    public int? PublisherId { get; set; }
+
+    /// <summary>Returns true when at least one filter is active.</summary>
+    public bool HasActiveFilters => CategoryId.HasValue || PublisherId.HasValue;
+}

--- a/server/TailspinToys.Api.Tests/TestCategoriesRoutes.cs
+++ b/server/TailspinToys.Api.Tests/TestCategoriesRoutes.cs
@@ -27,6 +27,9 @@ public class TestCategoriesRoutes : IDisposable
         new() { ["name"] = "Cooperative", ["description"] = "Games where players work together" }
     ];
 
+    // Category that has no games — should not appear in the API response.
+    private const string UnusedCategoryName = "Unused Category";
+
     private const string CategoriesApiPath = "/api/categories";
 
     public TestCategoriesRoutes()
@@ -56,12 +59,36 @@ public class TestCategoriesRoutes : IDisposable
 
     private static void SeedTestData(TailspinToysContext db)
     {
-        var categories = TestCategories.Select(c => new Category
+        // Seed a publisher required by the Game FK.
+        var publisher = new Publisher { Name = "Test Publisher", Description = "A test publisher" };
+        db.Publishers.Add(publisher);
+
+        // Seed categories — each used category gets at least one game.
+        var usedCategories = TestCategories.Select(c => new Category
         {
-            Name = (string)c["name"],
+            Name        = (string)c["name"],
             Description = (string)c["description"]
-        });
-        db.Categories.AddRange(categories);
+        }).ToList();
+        db.Categories.AddRange(usedCategories);
+
+        // Seed a category that has no games attached — must not appear in the response.
+        var unusedCategory = new Category { Name = UnusedCategoryName, Description = "No games here" };
+        db.Categories.Add(unusedCategory);
+
+        db.SaveChanges();
+
+        // Attach one game to each used category so the endpoint returns them.
+        foreach (var category in usedCategories)
+        {
+            db.Games.Add(new Game
+            {
+                Title       = $"Game for {category.Name}",
+                Description = "A test game for filter endpoint coverage.",
+                CategoryId  = category.Id,
+                PublisherId = publisher.Id
+            });
+        }
+
         db.SaveChanges();
     }
 
@@ -149,6 +176,7 @@ public class TestCategoriesRoutes : IDisposable
     {
         using var scope = _factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<TailspinToysContext>();
+        db.Games.RemoveRange(db.Games);
         db.Categories.RemoveRange(db.Categories);
         db.SaveChanges();
 
@@ -158,6 +186,32 @@ public class TestCategoriesRoutes : IDisposable
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.NotNull(data);
         Assert.Empty(data);
+    }
+
+    /// <summary>
+    /// GET /api/categories omits categories that have no associated games.
+    /// </summary>
+    [Fact]
+    public async Task GetCategories_OnlyReturnsUsedCategories()
+    {
+        var response = await _client.GetAsync(CategoriesApiPath);
+        var data = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+
+        var returnedNames = data
+            .Select(c => Assert.IsType<JsonElement>(c["name"]).GetString())
+            .ToHashSet();
+
+        // The unused category must not be present.
+        Assert.DoesNotContain(UnusedCategoryName, returnedNames);
+
+        // All used categories must be present.
+        foreach (var expected in TestCategories)
+        {
+            Assert.Contains(expected["name"].ToString(), returnedNames);
+        }
     }
 
     public void Dispose()

--- a/server/TailspinToys.Api.Tests/TestCategoriesRoutes.cs
+++ b/server/TailspinToys.Api.Tests/TestCategoriesRoutes.cs
@@ -1,0 +1,177 @@
+// This file contains integration tests for the categories API endpoints.
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using TailspinToys.Api;
+using TailspinToys.Api.Models;
+
+namespace TailspinToys.Api.Tests;
+
+/// <summary>
+/// Integration tests for the /api/categories endpoint.
+/// </summary>
+public class TestCategoriesRoutes : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+
+    private static readonly Dictionary<string, object>[] TestCategories =
+    [
+        new() { ["name"] = "Strategy",    ["description"] = "Strategic thinking games" },
+        new() { ["name"] = "Card Game",   ["description"] = "Games played with cards" },
+        new() { ["name"] = "Cooperative", ["description"] = "Games where players work together" }
+    ];
+
+    private const string CategoriesApiPath = "/api/categories";
+
+    public TestCategoriesRoutes()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"TestDb_{Guid.NewGuid()}.db");
+        var connectionString = $"Data Source={_dbPath}";
+
+        _factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.UseEnvironment("Testing");
+                builder.ConfigureAppConfiguration((context, config) =>
+                {
+                    config.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["ConnectionStrings:DefaultConnection"] = connectionString
+                    });
+                });
+            });
+
+        _client = _factory.CreateClient();
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TailspinToysContext>();
+        SeedTestData(db);
+    }
+
+    private static void SeedTestData(TailspinToysContext db)
+    {
+        var categories = TestCategories.Select(c => new Category
+        {
+            Name = (string)c["name"],
+            Description = (string)c["description"]
+        });
+        db.Categories.AddRange(categories);
+        db.SaveChanges();
+    }
+
+    /// <summary>
+    /// GET /api/categories returns 200 with all seeded categories.
+    /// </summary>
+    [Fact]
+    public async Task GetCategories_ReturnsAllCategories()
+    {
+        var response = await _client.GetAsync(CategoriesApiPath);
+        var data = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.Equal(TestCategories.Length, data.Count);
+    }
+
+    /// <summary>
+    /// GET /api/categories returns the correct id and name fields.
+    /// </summary>
+    [Fact]
+    public async Task GetCategories_ReturnsCorrectStructure()
+    {
+        var response = await _client.GetAsync(CategoriesApiPath);
+        var data = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.NotEmpty(data);
+
+        foreach (var category in data)
+        {
+            Assert.True(category.ContainsKey("id"),   "Missing field: id");
+            Assert.True(category.ContainsKey("name"), "Missing field: name");
+        }
+    }
+
+    /// <summary>
+    /// GET /api/categories does not expose extraneous fields such as description.
+    /// </summary>
+    [Fact]
+    public async Task GetCategories_DoesNotExposeExtraFields()
+    {
+        var response = await _client.GetAsync(CategoriesApiPath);
+        var data = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.NotEmpty(data);
+
+        foreach (var category in data)
+        {
+            Assert.False(category.ContainsKey("description"), "Unexpected field: description");
+            Assert.False(category.ContainsKey("gameCount"),   "Unexpected field: gameCount");
+        }
+    }
+
+    /// <summary>
+    /// GET /api/categories returns the correct category names matching seeded data.
+    /// </summary>
+    [Fact]
+    public async Task GetCategories_ReturnsCorrectNames()
+    {
+        var response = await _client.GetAsync(CategoriesApiPath);
+        var data = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+
+        var returnedNames = data
+            .Select(c => Assert.IsType<JsonElement>(c["name"]).GetString())
+            .ToHashSet();
+
+        foreach (var expected in TestCategories)
+        {
+            Assert.Contains(expected["name"].ToString(), returnedNames);
+        }
+    }
+
+    /// <summary>
+    /// GET /api/categories on an empty database returns an empty list (not 404).
+    /// </summary>
+    [Fact]
+    public async Task GetCategories_EmptyDatabase_ReturnsEmptyList()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TailspinToysContext>();
+        db.Categories.RemoveRange(db.Categories);
+        db.SaveChanges();
+
+        var response = await _client.GetAsync(CategoriesApiPath);
+        var data = await response.Content.ReadFromJsonAsync<List<object>>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.Empty(data);
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+        try
+        {
+            if (File.Exists(_dbPath))
+                File.Delete(_dbPath);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup
+        }
+    }
+}

--- a/server/TailspinToys.Api.Tests/TestGamesFilterRoutes.cs
+++ b/server/TailspinToys.Api.Tests/TestGamesFilterRoutes.cs
@@ -1,0 +1,204 @@
+// This file contains integration tests for the filtering query parameters on the games API.
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using TailspinToys.Api;
+using TailspinToys.Api.Models;
+
+namespace TailspinToys.Api.Tests;
+
+/// <summary>
+/// Integration tests for category and publisher filtering on GET /api/games.
+/// </summary>
+public class TestGamesFilterRoutes : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+
+    // Two publishers
+    private static readonly string PublisherA = "DevGames Inc";
+    private static readonly string PublisherB = "Scrum Masters";
+
+    // Two categories
+    private static readonly string CategoryStrategy = "Strategy";
+    private static readonly string CategoryCard = "Card Game";
+
+    private const string GamesApiPath = "/api/games";
+
+    // IDs are resolved after seeding
+    private int _publisherAId;
+    private int _publisherBId;
+    private int _categoryStrategyId;
+    private int _categoryCardId;
+
+    public TestGamesFilterRoutes()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"TestDb_{Guid.NewGuid()}.db");
+        var connectionString = $"Data Source={_dbPath}";
+
+        _factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.UseEnvironment("Testing");
+                builder.ConfigureAppConfiguration((_, config) =>
+                {
+                    config.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["ConnectionStrings:DefaultConnection"] = connectionString
+                    });
+                });
+            });
+
+        _client = _factory.CreateClient();
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TailspinToysContext>();
+        SeedTestData(db);
+    }
+
+    private void SeedTestData(TailspinToysContext db)
+    {
+        var pubA = new Publisher { Name = PublisherA };
+        var pubB = new Publisher { Name = PublisherB };
+        db.Publishers.AddRange(pubA, pubB);
+
+        var catS = new Category { Name = CategoryStrategy };
+        var catC = new Category { Name = CategoryCard };
+        db.Categories.AddRange(catS, catC);
+        db.SaveChanges();
+
+        _publisherAId     = pubA.Id;
+        _publisherBId     = pubB.Id;
+        _categoryStrategyId = catS.Id;
+        _categoryCardId     = catC.Id;
+
+        db.Games.AddRange(
+            // publisher A, strategy
+            new Game { Title = "Pipeline Panic",   Description = "Build your DevOps pipeline", StarRating = 4.5, Publisher = pubA, Category = catS },
+            // publisher A, card
+            new Game { Title = "Standup Shuffle",  Description = "Daily standup card game",    StarRating = 3.8, Publisher = pubA, Category = catC },
+            // publisher B, strategy
+            new Game { Title = "Sprint Sprint Sprint", Description = "Race through your backlog", StarRating = 4.2, Publisher = pubB, Category = catS },
+            // publisher B, card
+            new Game { Title = "Agile Adventures", Description = "Navigate sprints",            StarRating = 4.0, Publisher = pubB, Category = catC }
+        );
+        db.SaveChanges();
+    }
+
+    /// <summary>
+    /// No filter params — returns all four games.
+    /// </summary>
+    [Fact]
+    public async Task GetGames_NoFilter_ReturnsAllGames()
+    {
+        var response = await _client.GetAsync(GamesApiPath);
+        var data = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.Equal(4, data.Count);
+    }
+
+    /// <summary>
+    /// Filter by categoryId — returns only games in that category.
+    /// </summary>
+    [Fact]
+    public async Task GetGames_FilterByCategoryId_ReturnsMatchingGames()
+    {
+        var response = await _client.GetAsync($"{GamesApiPath}?categoryId={_categoryStrategyId}");
+        var data = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.Equal(2, data.Count);
+
+        foreach (var game in data)
+        {
+            var category = Assert.IsType<JsonElement>(game["category"]);
+            Assert.Equal(CategoryStrategy, category.GetProperty("name").GetString());
+        }
+    }
+
+    /// <summary>
+    /// Filter by publisherId — returns only games from that publisher.
+    /// </summary>
+    [Fact]
+    public async Task GetGames_FilterByPublisherId_ReturnsMatchingGames()
+    {
+        var response = await _client.GetAsync($"{GamesApiPath}?publisherId={_publisherAId}");
+        var data = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.Equal(2, data.Count);
+
+        foreach (var game in data)
+        {
+            var publisher = Assert.IsType<JsonElement>(game["publisher"]);
+            Assert.Equal(PublisherA, publisher.GetProperty("name").GetString());
+        }
+    }
+
+    /// <summary>
+    /// Filter by both categoryId and publisherId — returns only the game matching both.
+    /// </summary>
+    [Fact]
+    public async Task GetGames_FilterByCategoryAndPublisher_ReturnsIntersection()
+    {
+        var response = await _client.GetAsync($"{GamesApiPath}?categoryId={_categoryStrategyId}&publisherId={_publisherAId}");
+        var data = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.Single(data);
+        Assert.Equal("Pipeline Panic", data[0]["title"]?.ToString());
+    }
+
+    /// <summary>
+    /// Filter with a categoryId that matches no games returns an empty list.
+    /// </summary>
+    [Fact]
+    public async Task GetGames_FilterByUnknownCategoryId_ReturnsEmptyList()
+    {
+        var response = await _client.GetAsync($"{GamesApiPath}?categoryId=9999");
+        var data = await response.Content.ReadFromJsonAsync<List<object>>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.Empty(data);
+    }
+
+    /// <summary>
+    /// Filter with a publisherId that matches no games returns an empty list.
+    /// </summary>
+    [Fact]
+    public async Task GetGames_FilterByUnknownPublisherId_ReturnsEmptyList()
+    {
+        var response = await _client.GetAsync($"{GamesApiPath}?publisherId=9999");
+        var data = await response.Content.ReadFromJsonAsync<List<object>>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.Empty(data);
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+        try
+        {
+            if (File.Exists(_dbPath))
+                File.Delete(_dbPath);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup
+        }
+    }
+}

--- a/server/TailspinToys.Api.Tests/TestPublishersRoutes.cs
+++ b/server/TailspinToys.Api.Tests/TestPublishersRoutes.cs
@@ -27,6 +27,9 @@ public class TestPublishersRoutes : IDisposable
         new() { ["name"] = "Binary Bros",   ["description"] = "Puzzle and logic game studio" }
     ];
 
+    // Publisher that has no games — should not appear in the API response.
+    private const string UnusedPublisherName = "Unused Publisher";
+
     private const string PublishersApiPath = "/api/publishers";
 
     public TestPublishersRoutes()
@@ -57,12 +60,36 @@ public class TestPublishersRoutes : IDisposable
 
     private static void SeedTestData(TailspinToysContext db)
     {
-        var publishers = TestPublishers.Select(p => new Publisher
+        // Seed a category required by the Game FK.
+        var category = new Category { Name = "Test Category", Description = "A test category" };
+        db.Categories.Add(category);
+
+        // Seed publishers — each used publisher gets at least one game.
+        var usedPublishers = TestPublishers.Select(p => new Publisher
         {
-            Name = (string)p["name"],
+            Name        = (string)p["name"],
             Description = (string)p["description"]
-        });
-        db.Publishers.AddRange(publishers);
+        }).ToList();
+        db.Publishers.AddRange(usedPublishers);
+
+        // Seed a publisher that has no games attached — must not appear in the response.
+        var unusedPublisher = new Publisher { Name = UnusedPublisherName, Description = "No games here" };
+        db.Publishers.Add(unusedPublisher);
+
+        db.SaveChanges();
+
+        // Attach one game to each used publisher so the endpoint returns them.
+        foreach (var publisher in usedPublishers)
+        {
+            db.Games.Add(new Game
+            {
+                Title       = $"Game for {publisher.Name}",
+                Description = "A test game for filter endpoint coverage.",
+                CategoryId  = category.Id,
+                PublisherId = publisher.Id
+            });
+        }
+
         db.SaveChanges();
     }
 
@@ -150,6 +177,7 @@ public class TestPublishersRoutes : IDisposable
     {
         using var scope = _factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<TailspinToysContext>();
+        db.Games.RemoveRange(db.Games);
         db.Publishers.RemoveRange(db.Publishers);
         db.SaveChanges();
 
@@ -159,6 +187,32 @@ public class TestPublishersRoutes : IDisposable
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.NotNull(data);
         Assert.Empty(data);
+    }
+
+    /// <summary>
+    /// GET /api/publishers omits publishers that have no associated games.
+    /// </summary>
+    [Fact]
+    public async Task GetPublishers_OnlyReturnsUsedPublishers()
+    {
+        var response = await _client.GetAsync(PublishersApiPath);
+        var data = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+
+        var returnedNames = data
+            .Select(p => Assert.IsType<JsonElement>(p["name"]).GetString())
+            .ToHashSet();
+
+        // The unused publisher must not be present.
+        Assert.DoesNotContain(UnusedPublisherName, returnedNames);
+
+        // All used publishers must be present.
+        foreach (var expected in TestPublishers)
+        {
+            Assert.Contains(expected["name"].ToString(), returnedNames);
+        }
     }
 
     public void Dispose()

--- a/server/TailspinToys.Api.Tests/TestPublishersRoutes.cs
+++ b/server/TailspinToys.Api.Tests/TestPublishersRoutes.cs
@@ -1,0 +1,178 @@
+// This file contains integration tests for the publishers API endpoints.
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using TailspinToys.Api;
+using TailspinToys.Api.Models;
+
+namespace TailspinToys.Api.Tests;
+
+/// <summary>
+/// Integration tests for the /api/publishers endpoint.
+/// </summary>
+public class TestPublishersRoutes : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+
+    private static readonly Dictionary<string, object>[] TestPublishers =
+    [
+        new() { ["name"] = "DevGames Inc", ["description"] = "Makers of developer-themed games" },
+        new() { ["name"] = "Scrum Masters", ["description"] = "Agile board game experts" },
+        new() { ["name"] = "Binary Bros",   ["description"] = "Puzzle and logic game studio" }
+    ];
+
+    private const string PublishersApiPath = "/api/publishers";
+
+    public TestPublishersRoutes()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"TestDb_{Guid.NewGuid()}.db");
+        var connectionString = $"Data Source={_dbPath}";
+
+        _factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.UseEnvironment("Testing");
+
+                builder.ConfigureAppConfiguration((context, config) =>
+                {
+                    config.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["ConnectionStrings:DefaultConnection"] = connectionString
+                    });
+                });
+            });
+
+        _client = _factory.CreateClient();
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TailspinToysContext>();
+        SeedTestData(db);
+    }
+
+    private static void SeedTestData(TailspinToysContext db)
+    {
+        var publishers = TestPublishers.Select(p => new Publisher
+        {
+            Name = (string)p["name"],
+            Description = (string)p["description"]
+        });
+        db.Publishers.AddRange(publishers);
+        db.SaveChanges();
+    }
+
+    /// <summary>
+    /// GET /api/publishers returns 200 with all seeded publishers.
+    /// </summary>
+    [Fact]
+    public async Task GetPublishers_ReturnsAllPublishers()
+    {
+        var response = await _client.GetAsync(PublishersApiPath);
+        var data = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.Equal(TestPublishers.Length, data.Count);
+    }
+
+    /// <summary>
+    /// GET /api/publishers returns the correct id and name fields for each publisher.
+    /// </summary>
+    [Fact]
+    public async Task GetPublishers_ReturnsCorrectStructure()
+    {
+        var response = await _client.GetAsync(PublishersApiPath);
+        var data = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.NotEmpty(data);
+
+        foreach (var publisher in data)
+        {
+            Assert.True(publisher.ContainsKey("id"), "Missing field: id");
+            Assert.True(publisher.ContainsKey("name"), "Missing field: name");
+        }
+    }
+
+    /// <summary>
+    /// GET /api/publishers does not include extraneous fields such as description.
+    /// </summary>
+    [Fact]
+    public async Task GetPublishers_DoesNotExposeExtraFields()
+    {
+        var response = await _client.GetAsync(PublishersApiPath);
+        var data = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.NotEmpty(data);
+
+        foreach (var publisher in data)
+        {
+            Assert.False(publisher.ContainsKey("description"), "Unexpected field: description");
+            Assert.False(publisher.ContainsKey("gameCount"),   "Unexpected field: gameCount");
+        }
+    }
+
+    /// <summary>
+    /// GET /api/publishers returns publishers with correct names matching seeded data.
+    /// </summary>
+    [Fact]
+    public async Task GetPublishers_ReturnsCorrectNames()
+    {
+        var response = await _client.GetAsync(PublishersApiPath);
+        var data = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+
+        var returnedNames = data
+            .Select(p => Assert.IsType<JsonElement>(p["name"]).GetString())
+            .ToHashSet();
+
+        foreach (var expected in TestPublishers)
+        {
+            Assert.Contains(expected["name"].ToString(), returnedNames);
+        }
+    }
+
+    /// <summary>
+    /// GET /api/publishers on an empty database returns an empty list (not 404).
+    /// </summary>
+    [Fact]
+    public async Task GetPublishers_EmptyDatabase_ReturnsEmptyList()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TailspinToysContext>();
+        db.Publishers.RemoveRange(db.Publishers);
+        db.SaveChanges();
+
+        var response = await _client.GetAsync(PublishersApiPath);
+        var data = await response.Content.ReadFromJsonAsync<List<object>>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.Empty(data);
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+        try
+        {
+            if (File.Exists(_dbPath))
+                File.Delete(_dbPath);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup
+        }
+    }
+}

--- a/server/TailspinToys.Api/Program.cs
+++ b/server/TailspinToys.Api/Program.cs
@@ -54,6 +54,8 @@ app.UseCors();
 
 // Register routes
 app.MapGamesRoutes();
+app.MapPublishersRoutes();
+app.MapCategoriesRoutes();
 
 app.Run();
 

--- a/server/TailspinToys.Api/Routes/CategoriesRoutes.cs
+++ b/server/TailspinToys.Api/Routes/CategoriesRoutes.cs
@@ -1,0 +1,31 @@
+// This file defines the Minimal API route group for category-related endpoints.
+using Microsoft.EntityFrameworkCore;
+using TailspinToys.Api;
+
+namespace TailspinToys.Api.Routes;
+
+/// <summary>
+/// Extension methods for registering category API routes.
+/// </summary>
+public static class CategoriesRoutes
+{
+    /// <summary>
+    /// Maps all category-related API endpoints onto the application.
+    /// </summary>
+    /// <param name="app">The web application to register routes on.</param>
+    public static void MapCategoriesRoutes(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/categories");
+
+        group.MapGet("/", async (TailspinToysContext db) =>
+        {
+            var categories = await db.Categories
+                .Where(c => c.Games.Any())
+                .OrderBy(c => c.Id)
+                .Select(c => new { c.Id, c.Name })
+                .ToListAsync();
+
+            return Results.Ok(categories);
+        });
+    }
+}

--- a/server/TailspinToys.Api/Routes/GamesRoutes.cs
+++ b/server/TailspinToys.Api/Routes/GamesRoutes.cs
@@ -1,22 +1,36 @@
-using Microsoft.AspNetCore.Http.HttpResults;
+// This file defines the Minimal API route group for game-related endpoints.
 using Microsoft.EntityFrameworkCore;
 using TailspinToys.Api;
 
 namespace TailspinToys.Api.Routes;
 
+/// <summary>
+/// Extension methods for registering game API routes.
+/// </summary>
 public static class GamesRoutes
 {
+    /// <summary>
+    /// Maps all game-related API endpoints onto the application.
+    /// </summary>
+    /// <param name="app">The web application to register routes on.</param>
     public static void MapGamesRoutes(this WebApplication app)
     {
         var group = app.MapGroup("/api/games");
 
-        group.MapGet("/", async (TailspinToysContext db) =>
+        group.MapGet("/", async (TailspinToysContext db, int? categoryId, int? publisherId) =>
         {
-            var games = await db.Games
+            var query = db.Games
                 .Include(g => g.Publisher)
                 .Include(g => g.Category)
-                .OrderBy(g => g.Id)
-                .ToListAsync();
+                .AsQueryable();
+
+            if (categoryId.HasValue)
+                query = query.Where(g => g.CategoryId == categoryId.Value);
+
+            if (publisherId.HasValue)
+                query = query.Where(g => g.PublisherId == publisherId.Value);
+
+            var games = await query.OrderBy(g => g.Id).ToListAsync();
 
             return Results.Ok(games.Select(g => g.ToDict()));
         });

--- a/server/TailspinToys.Api/Routes/PublishersRoutes.cs
+++ b/server/TailspinToys.Api/Routes/PublishersRoutes.cs
@@ -1,3 +1,31 @@
+// This file defines the Minimal API route group for publisher-related endpoints.
+using Microsoft.EntityFrameworkCore;
+using TailspinToys.Api;
+
 namespace TailspinToys.Api.Routes;
 
-// Publishers routes - placeholder for future implementation
+/// <summary>
+/// Extension methods for registering publisher API routes.
+/// </summary>
+public static class PublishersRoutes
+{
+    /// <summary>
+    /// Maps all publisher-related API endpoints onto the application.
+    /// </summary>
+    /// <param name="app">The web application to register routes on.</param>
+    public static void MapPublishersRoutes(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/publishers");
+
+        group.MapGet("/", async (TailspinToysContext db) =>
+        {
+            var publishers = await db.Publishers
+                .Where(p => p.Games.Any())
+                .OrderBy(p => p.Id)
+                .Select(p => new { p.Id, p.Name })
+                .ToListAsync();
+
+            return Results.Ok(publishers);
+        });
+    }
+}


### PR DESCRIPTION
## Why

The games list page showed all games in a single unfiltered list, making it hard for users to find games relevant to their interests. This PR implements issue #13 by adding category and publisher filter controls.

Closes #13

## Changes

- **New API endpoints** — `GET /api/categories` and `GET /api/publishers` return only entries that have at least one associated game (satisfying AC #7)
- **Games filter** — `GET /api/games` now accepts `categoryId` and `publisherId` query parameters for server-side filtering
- **`GameFilter` component** — renders filter badge pills for categories and publishers with active state (aria-pressed), and a "Clear filters" button
- **`GameFilterState` model** — client-side state object tracking active category/publisher selection
- **`GameList` component** — integrates `GameFilter`, calls the API with active filters on change, and shows an `EmptyState` when no results match
- **`EmptyState` component** — displays a friendly message when no games match the current filters
- **Fix: `GameFilter` rendermode** — removed redundant `@rendermode InteractiveServer` from `GameFilter.razor`; as a child of the already-interactive `GameList`, declaring a render mode created a competing Blazor circuit that prevented `aria-pressed` from updating correctly on publisher badge clicks

## Tests

### Server integration tests (30/30 ✅)
- `TestCategoriesRoutes` — covers structure, field exposure, correct names, empty DB, and **only returns categories with games**
- `TestPublishersRoutes` — same coverage for publishers
- `TestGamesFilterRoutes` — covers filtering by category, publisher, both combined, and no-match results

### E2E tests (27/27 ✅)
- `FilterTests` — covers filter panel visibility, category badge filtering, publisher badge filtering, combined filters, clear filters, and badge toggle (deselect on second click)

## Key implementation details

### Only populated filter options are shown

```csharp
// CategoriesRoutes.cs
var categories = await db.Categories
    .Where(c => c.Games.Any())
    .OrderBy(c => c.Id)
    .Select(c => new { c.Id, c.Name })
    .ToListAsync();
```

### Filter state updates without a full page reload

```razor
// GameList.razor — reacts to filter changes from the child component
<GameFilter FilterChanged="OnFilterChanged" />

@code {
    private async Task OnFilterChanged(GameFilterState filter)
    {
        currentFilter = new GameFilterState { CategoryId = filter.CategoryId, PublisherId = filter.PublisherId };
        await FetchGames();
    }
}
```
