### PR TITLE
fix(a11y): correct heading hierarchy — About page h2 → h1

### DIFF
--- a/client/TailspinToys.E2E/AccessibilityTests.cs
+++ b/client/TailspinToys.E2E/AccessibilityTests.cs
@@ -240,6 +240,109 @@ public class AccessibilityTests : PlaywrightTestBase
         }
     }
 
+    // ── Heading hierarchy ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies the home page has exactly one h1 with the correct text.
+    /// </summary>
+    [Fact]
+    public async Task HeadingHierarchyShouldHaveExactlyOneH1OnHomePage()
+    {
+        await Page.GotoAsync("/");
+        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 10000 });
+
+        var h1s = Page.GetByRole(AriaRole.Heading, new() { Level = 1 });
+        Assert.Equal(1, await h1s.CountAsync());
+        await Expect(h1s.First).ToHaveTextAsync("Welcome to Tailspin Toys");
+    }
+
+    /// <summary>
+    /// Verifies the about page has exactly one h1 with the correct text.
+    /// </summary>
+    [Fact]
+    public async Task HeadingHierarchyShouldHaveExactlyOneH1OnAboutPage()
+    {
+        await Page.GotoAsync("/about");
+        await Page.WaitForSelectorAsync("[data-testid='about-section']", new() { Timeout = 10000 });
+
+        var h1s = Page.GetByRole(AriaRole.Heading, new() { Level = 1 });
+        Assert.Equal(1, await h1s.CountAsync());
+        await Expect(h1s.First).ToHaveTextAsync("About Tailspin Toys");
+    }
+
+    /// <summary>
+    /// Verifies the game details page has exactly one h1 (the game title).
+    /// </summary>
+    [Fact]
+    public async Task HeadingHierarchyShouldHaveExactlyOneH1OnGameDetailsPage()
+    {
+        await Page.GotoAsync("/game/1");
+        await Page.WaitForSelectorAsync("[data-testid='game-details']", new() { Timeout = 10000 });
+
+        var h1s = Page.GetByRole(AriaRole.Heading, new() { Level = 1 });
+        Assert.Equal(1, await h1s.CountAsync());
+        await Expect(h1s.First).Not.ToBeEmptyAsync();
+    }
+
+    /// <summary>
+    /// Verifies that heading levels do not skip on the home page
+    /// (e.g. no h3 without a preceding h2, no h2 without a preceding h1).
+    /// </summary>
+    [Fact]
+    public async Task HeadingsShouldNotSkipLevelsOnHomePage()
+    {
+        await Page.GotoAsync("/");
+        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 10000 });
+
+        await AssertHeadingHierarchyAsync(Page);
+    }
+
+    /// <summary>
+    /// Verifies that heading levels do not skip on the about page.
+    /// </summary>
+    [Fact]
+    public async Task HeadingsShouldNotSkipLevelsOnAboutPage()
+    {
+        await Page.GotoAsync("/about");
+        await Page.WaitForSelectorAsync("[data-testid='about-section']", new() { Timeout = 10000 });
+
+        await AssertHeadingHierarchyAsync(Page);
+    }
+
+    /// <summary>
+    /// Verifies that heading levels do not skip on the game details page.
+    /// </summary>
+    [Fact]
+    public async Task HeadingsShouldNotSkipLevelsOnGameDetailsPage()
+    {
+        await Page.GotoAsync("/game/1");
+        await Page.WaitForSelectorAsync("[data-testid='game-details']", new() { Timeout = 10000 });
+
+        await AssertHeadingHierarchyAsync(Page);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Asserts that headings on the current page start at h1 and never skip a level.
+    /// </summary>
+    private static async Task AssertHeadingHierarchyAsync(IPage page)
+    {
+        var levels = await page.EvaluateAsync<int[]>(@"() =>
+            Array.from(document.querySelectorAll('h1,h2,h3,h4,h5,h6'))
+                 .map(h => parseInt(h.tagName[1]))");
+
+        Assert.NotEmpty(levels);
+        Assert.Equal(1, levels[0]);
+
+        for (var i = 1; i < levels.Length; i++)
+        {
+            var jump = levels[i] - levels[i - 1];
+            Assert.True(jump <= 1,
+                $"Heading skips from h{levels[i - 1]} to h{levels[i]} at position {i} — no heading levels should be skipped.");
+        }
+    }
+
     private static ILocatorAssertions Expect(ILocator locator) => Assertions.Expect(locator);
     private static IPageAssertions Expect(IPage page) => Assertions.Expect(page);
 }

--- a/client/TailspinToys.Web/Components/Pages/About.razor
+++ b/client/TailspinToys.Web/Components/Pages/About.razor
@@ -4,7 +4,7 @@
 
 <section class="max-w-5xl mx-auto px-4 py-8" data-testid="about-section">
     <div class="bg-slate-800/70 backdrop-blur-sm border border-slate-700 rounded-xl shadow-lg p-8 transition-colors duration-300">
-        <h2 class="text-blue-400 text-4xl mb-8 pb-3 border-b border-slate-600 font-bold" data-testid="about-heading">About Tailspin Toys</h2>
+        <h1 class="text-blue-400 text-4xl mb-8 pb-3 border-b border-slate-600 font-bold" data-testid="about-heading">About Tailspin Toys</h1>
 
         <div class="space-y-6">
             <p class="text-lg leading-relaxed text-slate-300">


### PR DESCRIPTION
## Why

Part of the accessibility review (issue #14), scoped to heading hierarchy.

The **About page** used `<h2>` as its first and only heading, with no `<h1>` anywhere on the page. Screen reader users who navigate by headings would land on an `h2` implying a parent section that does not exist — a violation of WCAG 1.3.1 (Info and Relationships) and heading best practice (2.4.6 Headings and Labels).

All other pages (Home, Game Details, Not Found) already had correct heading hierarchy.

Closes #14 (heading stage)

---

## Changes

- **`client/TailspinToys.Web/Components/Pages/About.razor`** — changed `<h2>` → `<h1>` for the "About Tailspin Toys" page heading
- **`client/TailspinToys.E2E/AccessibilityTests.cs`** — added 6 heading-specific E2E tests

---

## Heading hierarchy (post-fix)

| Page | h1 | h2 | h3 |
|---|---|---|---|
| Home `/` | "Welcome to Tailspin Toys" ✅ | "Featured Games" ✅ | "Category", "Publisher" ✅ |
| About `/about` | "About Tailspin Toys" ✅ *(was h2)* | — | — |
| Game details `/game/{id}` | Game title ✅ | "About this game" ✅ | — |

---

## New E2E tests

```csharp
// Verify each page has exactly one h1
HeadingHierarchyShouldHaveExactlyOneH1OnHomePage
HeadingHierarchyShouldHaveExactlyOneH1OnAboutPage
HeadingHierarchyShouldHaveExactlyOneH1OnGameDetailsPage

// Verify no heading levels are skipped on any page
HeadingsShouldNotSkipLevelsOnHomePage
HeadingsShouldNotSkipLevelsOnAboutPage
HeadingsShouldNotSkipLevelsOnGameDetailsPage
```

The `HeadingsShouldNotSkipLevels*` tests use a shared `AssertHeadingHierarchyAsync` helper that:
1. Collects all heading elements in document order
2. Asserts the first is `h1`
3. Asserts each subsequent heading increases by at most one level

---

## Test results

- Backend: **30/30 ✅**
- E2E: **33/33 ✅** (6 new heading tests, all passing)
